### PR TITLE
Add cosmetic dumper, translation dumper and mushroom mixup cosmetics dumper

### DIFF
--- a/Dumpostor/Dumpers/CosmeticDumper.cs
+++ b/Dumpostor/Dumpers/CosmeticDumper.cs
@@ -57,15 +57,7 @@ namespace Dumpostor.Dumpers
                 cosmetics.Add(new Cosmetic("Visor", visor.ProdId, visor.Free, "", visor.beanCost, visor.starCost, visor.BundleId, visor.ChipOffset));
             }
 
-            return JsonSerializer.Serialize(cosmetics,
-                new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    Converters =
-                    {
-                        new Vector2Converter()
-                    }
-                });
+            return JsonSerializer.Serialize(cosmetics, DumpostorPlugin.JsonSerializerOptions);
         }
     }
 }

--- a/Dumpostor/Dumpers/CosmeticDumper.cs
+++ b/Dumpostor/Dumpers/CosmeticDumper.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using UnityEngine;
+
+namespace Dumpostor.Dumpers
+{
+    public class Cosmetic
+    {
+        public Cosmetic(string type, string name, bool free, string storeName, int beanCost, int starCost, string bundleId,
+            Vector2 chipOffset)
+        {
+            Type = type;
+            Name = name;
+            Free = free;
+            StoreName = storeName;
+            BeanCost = beanCost;
+            StarCost = starCost;
+            BundleId = bundleId;
+            ChipOffset = chipOffset;
+        }
+
+        public string Type { get; }
+        public string Name { get; }
+        public bool Free { get; }
+        public string StoreName { get; }
+        public int BeanCost { get; }
+        public int StarCost { get; }
+        public string BundleId { get; }
+        public Vector2 ChipOffset { get; }
+    }
+
+    public class CosmeticDumper : IDumper
+    {
+        public string FileName => "Cosmetics.json";
+
+        public string Dump()
+        {
+            List<Cosmetic> cosmetics = new List<Cosmetic>();
+            foreach (HatData hat in HatManager.Instance.allHats)
+            {
+                cosmetics.Add(new Cosmetic("Hat", hat.ProdId, hat.Free, hat.StoreName, hat.beanCost, hat.starCost, hat.BundleId, hat.ChipOffset));
+            }
+            foreach (SkinData skin in HatManager.Instance.allSkins)
+            {
+                cosmetics.Add(new Cosmetic("Skin", skin.ProdId, skin.Free, skin.StoreName, skin.beanCost, skin.starCost, skin.BundleId, skin.ChipOffset));
+            }
+            foreach (PetData pet in HatManager.Instance.allPets)
+            {
+                cosmetics.Add(new Cosmetic("Pet", pet.ProdId, pet.Free, "", pet.beanCost, pet.starCost, pet.BundleId, pet.ChipOffset));
+            }
+            foreach (NamePlateData nameplate in HatManager.Instance.allNamePlates)
+            {
+                cosmetics.Add(new Cosmetic("Nameplate", nameplate.ProdId, nameplate.Free, "", nameplate.beanCost, nameplate.starCost, nameplate.BundleId, nameplate.ChipOffset));
+            }
+            foreach (VisorData visor in HatManager.Instance.allVisors)
+            {
+                cosmetics.Add(new Cosmetic("Visor", visor.ProdId, visor.Free, "", visor.beanCost, visor.starCost, visor.BundleId, visor.ChipOffset));
+            }
+
+            return JsonSerializer.Serialize(cosmetics,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters =
+                    {
+                        new Vector2Converter()
+                    }
+                });
+        }
+    }
+}

--- a/Dumpostor/Dumpers/EnumDumper.cs
+++ b/Dumpostor/Dumpers/EnumDumper.cs
@@ -13,10 +13,7 @@ public sealed class EnumDumper<T> : IDumper where T : Enum
     {
         return JsonSerializer.Serialize(
             Extensions.GetValues<T>().ToDictionary(k => Enum.GetName(typeof(T), k), v => v),
-            new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            }
+            DumpostorPlugin.JsonSerializerOptions
         );
     }
 }

--- a/Dumpostor/Dumpers/Map/MushroomMixupCosmetics.cs
+++ b/Dumpostor/Dumpers/Map/MushroomMixupCosmetics.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using UnityEngine;
+
+namespace Dumpostor.Dumpers.Map;
+
+public sealed class MushroomMixupCosmeticsDumper
+{
+    public string FileName => "mixup.json";
+
+    public string Dump(FungleShipStatus shipStatus)
+    {
+        return JsonSerializer.Serialize(MixupCosmetics.From(shipStatus.specialSabotage), DumpostorPlugin.JsonSerializerOptions);
+    }
+
+    public sealed class MixupCosmetics
+    {
+        public required string[] HatIds { get; init; }
+        public required string[] VisorIds { get; init; }
+        public required string[] PetIds { get; init; }
+
+        public static MixupCosmetics From(MushroomMixupSabotageSystem system)
+        {
+            return new MixupCosmetics
+            {
+                HatIds = system.hatIds,
+                VisorIds = system.visorIds,
+                PetIds = system.petIds,
+            };
+        }
+    }
+}

--- a/Dumpostor/Dumpers/TranslationsDumper.cs
+++ b/Dumpostor/Dumpers/TranslationsDumper.cs
@@ -1,11 +1,35 @@
+using System;
+using System.Text.Json;
+using System.Collections.Generic;
+
 namespace Dumpostor.Dumpers;
 
 public sealed class TranslationsDumper : IDumper
 {
-    public string FileName => "translations.txt";
+    public string FileName => "translations.json";
 
     public string Dump()
     {
-        return TranslationController.Instance.Languages[SupportedLangs.English].Data.text;
+        var supportedLangs = Enum.GetValues(typeof(SupportedLangs));
+        
+        var languages = new Dictionary<SupportedLangs, Dictionary<string, string>>();
+
+        foreach (SupportedLangs lang in supportedLangs) {
+            TranslatedImageSet languageImageSet = TranslationController.Instance.Languages[lang];
+            LanguageUnit languageUnit = new(languageImageSet);
+
+            Dictionary<string, string> AllStrings = new();
+
+            foreach (var entry in languageUnit.AllStrings) {
+                AllStrings.Add(entry.Key, entry.Value);
+            }
+
+            languages.Add(lang, AllStrings);
+        }
+
+        return JsonSerializer.Serialize(
+            languages,
+            DumpostorPlugin.JsonSerializerOptions
+        );
     }
 }

--- a/Dumpostor/DumpostorPlugin.cs
+++ b/Dumpostor/DumpostorPlugin.cs
@@ -136,6 +136,14 @@ public sealed partial class DumpostorPlugin : BasePlugin
 
             var shipStatus = UnityEngine.Object.Instantiate(shipStatusPrefab);
 
+            var fungleShipStatus = shipStatus.GetComponent<FungleShipStatus>();
+            if (fungleShipStatus != null) {
+                MushroomMixupCosmeticsDumper mixupDumper = new();
+                var outputPath = Path.Combine(mapDirectory, mixupDumper.FileName);
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                File.WriteAllText(outputPath, mixupDumper.Dump(fungleShipStatus));
+            }
+
             foreach (var dumper in mapDumpers)
             {
                 Info("Dumping " + dumper);

--- a/Dumpostor/DumpostorPlugin.cs
+++ b/Dumpostor/DumpostorPlugin.cs
@@ -85,6 +85,7 @@ public sealed partial class DumpostorPlugin : BasePlugin
             // new TranslationsDumper(),
 
             new ColorDumper(),
+            new CosmeticDumper(),
             new EnumDumper<DisconnectReasons>(),
             new EnumDumper<SanctionReasons>(),
             new EnumDumper<GameKeywords>(),

--- a/Dumpostor/DumpostorPlugin.cs
+++ b/Dumpostor/DumpostorPlugin.cs
@@ -82,7 +82,7 @@ public sealed partial class DumpostorPlugin : BasePlugin
         {
             new InfoDumper(),
             new SpawnableObjectsDumper(spawnableObjects),
-            // new TranslationsDumper(),
+            new TranslationsDumper(),
 
             new ColorDumper(),
             new CosmeticDumper(),


### PR DESCRIPTION
- Dumps hats, pets, skins, nameplates, visors, along with their bundle ids, store information and chip offsets.
- Re-enable translation dumper and now keys for _all_ languages, into JSON.
- Dump pre-defined Mushroom Mixup system cosmetics.

Example dumps:
[cosmetics.json](https://github.com/user-attachments/files/23292147/cosmetics.json)
[translations.json](https://github.com/user-attachments/files/23292140/translations.json)
[maps/Fungle/mixup.json](https://github.com/user-attachments/files/23292141/mixup.json)